### PR TITLE
Add @stack which stacks multiple structs into one. Closes #4

### DIFF
--- a/src/Mixers.jl
+++ b/src/Mixers.jl
@@ -117,7 +117,7 @@ macro stack(into, structs...)
     fields = []
     for _struct in structs
         names = fieldnames(getfield(__module__, _struct))
-        types = fieldtypes(getfield(__module__, _struct))
+        types = [fieldtype(getfield(__module__, _struct), field) for field in names]
         for (n, t) in zip(names, types)
             push!(fields, :($n::$t))
         end

--- a/src/Mixers.jl
+++ b/src/Mixers.jl
@@ -2,7 +2,7 @@ module Mixers
 
 using MacroTools
 
-export @mix, @premix, @pour
+export @mix, @premix, @pour, @stack
 
 """
 Generates simple macros for inserting any lines anywhere.
@@ -105,5 +105,31 @@ firsthead(f, ex, match) = nothing
 
 mergetypes(t1, t2, prepend) = prepend ? union(t2, t1) : union(t1, t2)
 mergefields(f1, f2, prepend) = prepend ? vcat(f2, f1) : vcat(f1, f2)
+
+
+"""
+Stack the fields of multiple structs and create a new one.
+The first argument is the name of the new struct followed by the
+ones to be stacked. Parametric types are not supported and
+the fieldnames needs to be unique.
+"""
+macro stack(into, structs...)
+    fields = []
+    for _struct in structs
+        names = fieldnames(getfield(__module__, _struct))
+        types = fieldtypes(getfield(__module__, _struct))
+        for (n, t) in zip(names, types)
+            push!(fields, :($n::$t))
+        end
+    end
+
+    esc(
+        quote
+            struct $into
+                $(fields...)
+            end
+        end
+    )
+end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,5 +155,7 @@ struct C
     u
 end
 @stack D A B C
-@test fieldnames(D) == (:n, :m, :o, :p, :q, :r, :s, :t, :u)
-@test fieldtypes(D) == (Int32, Int64, Float16, Any, Bool, Any, Any, Any, Any)
+expected_fieldnames = (:n, :m, :o, :p, :q, :r, :s, :t, :u)
+expected_fieldtypes = [Int32, Int64, Float16, Any, Bool, Any, Any, Any, Any]
+@test fieldnames(D) == expected_fieldnames
+@test [fieldtype(D, f) for f in fieldnames(D)] == expected_fieldtypes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,3 +136,24 @@ function sayhi()
    @hello
 end
 @test sayhi() == "Hello world"                                                                      
+
+
+# @stack
+struct A
+    n::Int32
+    m::Int64
+end
+struct B
+    o::Float16
+    p
+    q::Bool
+end
+struct C
+    r
+    s
+    t
+    u
+end
+@stack D A B C
+@test fieldnames(D) == (:n, :m, :o, :p, :q, :r, :s, :t, :u)
+@test fieldtypes(D) == (Int32, Int64, Float16, Any, Bool, Any, Any, Any, Any)


### PR DESCRIPTION
The `@stack` macro concatenates the types of the given structs and creates a new one.

Let me know what you think about this. It directly defines the structs, maybe you want it to provide a "template" as an intermediate step first, as proposed in https://github.com/rafaqz/Mixers.jl/issues/4 ?

```julia
julia> using Mixers

julia> struct Foo
         x::Int32
       end

julia> struct Bar
         y::Int64
       end

julia> @stack Baz Foo Bar

julia> fieldnames(Baz)
(:x, :y)

julia> fieldtypes(Baz)
(Int32, Int64)
```