### PR TITLE
fix package on 1.5

### DIFF
--- a/src/Mixers.jl
+++ b/src/Mixers.jl
@@ -74,7 +74,7 @@ function mix(ex, macros, mixtypes, mixfields, prepend)
 
     # wrap local and mixed macros around the struct
     for mac in reverse(union(localmacros, macros))
-        ex = Expr(:macrocall, mac, LineNumberNode(79, "Mixers.jl"), ex)
+        ex = Expr(:macrocall, mac, LineNumberNode(79, Symbol("Mixers.jl")), ex)
     end
     esc(ex)
 end


### PR DESCRIPTION
It seems that LineNumberNode needs a symbol now, and no longer accepts a string.

It would be nice with a new release with this since some packages fail on 1.5 when using this as a dependency. 