### PR TITLE
Allow mixing of macros that are defined in a different name space

### DIFF
--- a/src/Mixers.jl
+++ b/src/Mixers.jl
@@ -80,7 +80,7 @@ function mix(ex, macros, mixtypes, mixfields, prepend)
 end
 
 
-chained_macros(ex) = chained_macros!(Symbol[], ex) 
+chained_macros(ex) = chained_macros!(Union{Symbol, Expr}[], ex) 
 chained_macros!(macros, ex) = macros
 chained_macros!(macros, ex::Expr) = begin
     if ex.head == :macrocall


### PR DESCRIPTION
Currently, [it is not possible](https://github.com/GenieFramework/Stipple.jl/issues/110) to do
```julia
@mix Stipple.@with_kw mutable struct reactive
  Stipple.@reactors
end
```
as `Stipple.@with_kw` is not a Symbol but an expression. Therefore, it is currently not possible to use macros for mixing that are not available in the current name space. Changing the array type as proposed cures that short coming.